### PR TITLE
feat/fieldref-label-support

### DIFF
--- a/charts/netigate-helm-template/Chart.yaml
+++ b/charts/netigate-helm-template/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 3.1.7
+version: 3.1.8
 
 
 # This is the version number of the application being deployed. This version number should be

--- a/charts/netigate-helm-template/templates/deployment.yaml
+++ b/charts/netigate-helm-template/templates/deployment.yaml
@@ -6,6 +6,9 @@ metadata:
   labels:
     app: {{ .Values.name }}
     team: {{ .Values.team }}
+    {{- range $key, $val := .Values.metadata.labels }}
+    {{ $key }}: {{ $val | quote }}
+    {{- end }}
   annotations:
     reloader.stakater.com/auto: "true"
 spec:
@@ -15,11 +18,17 @@ spec:
   selector:
     matchLabels:
       app: {{ .Values.name }}
+      {{- range $key, $val := .Values.selector.matchLabels }}
+      {{ $key }}: {{ $val | quote }}
+      {{- end }}
   template:
     metadata:
       labels:
         app: {{ .Values.name }}
         team: {{ .Values.team }}
+        {{- range $key, $val := .Values.metadata.labels }}
+        {{ $key }}: {{ $val | quote }}
+        {{- end }}
       annotations:
         {{- if .Values.vault.enabled }}
         vault.hashicorp.com/log-format: json
@@ -40,6 +49,12 @@ spec:
           imagePullPolicy: IfNotPresent
           {{- if or .Values.grpc.enabled .Values.grpcExt.enabled .Values.postgres.enabled .Values.vault.enabled .Values.kafka.enabled .Values.globalKafka.enabled .Values.redis.enabled }}
           env:
+            {{- range $v := .Values.fieldRefs }}
+            - name: {{ $v.name }}
+              valueFrom:
+                fieldRef:
+                  fieldPath: {{ $v.data }}
+            {{- end }}
             {{- if .Values.vault.enabled }}
             {{- range .Values.vault.env }}
             - name: {{ .key }}

--- a/charts/netigate-helm-template/values.yaml
+++ b/charts/netigate-helm-template/values.yaml
@@ -9,6 +9,12 @@ replicaCount: 3
 
 imagePullSecrets: []
 
+metadata:
+  labels:
+
+selector:
+  matchLabels:
+
 resources:
   limits:
     cpu: 100m
@@ -91,3 +97,5 @@ alerts:
   enabled: true
 
 envVars:
+
+fieldRefs:


### PR DESCRIPTION
Add support to add field-ref environment variables as well as custom metadata labels and selector labels.

Ex. usage

```yaml
metadata:
  labels:
    orleans/serviceId: dictionary-app
    orleans/clusterId: dictionary-app

selector:
  matchLabels:
    orleans/serviceId: dictionary-app

fieldRefs:
  - name: ORLEANS_SERVICE_ID
    data: metadata.labels['orleans/serviceId']
  - name: ORLEANS_CLUSTER_ID
    data: metadata.labels['orleans/clusterId']
  - name: POD_NAMESPACE
    data: metadata.namespace
  - name: POD_NAME
    data: metadata.name
  - name: POD_IP
    data: status.podIP
```