### PR TITLE
feat: opentelemetry metrics

### DIFF
--- a/charts/namespace-v2/templates/OpenTelemetryCollector.yaml
+++ b/charts/namespace-v2/templates/OpenTelemetryCollector.yaml
@@ -19,7 +19,7 @@ spec:
         endpoint: tempo-distributor.tracing.svc.cluster.local:4317
         tls:
           insecure: true
-      prometheus:                                                                                                                                                          │
+      prometheus:
         endpoint: 0.0.0.0:9091
     service:
       pipelines:

--- a/charts/namespace-v2/templates/OpenTelemetryCollector.yaml
+++ b/charts/namespace-v2/templates/OpenTelemetryCollector.yaml
@@ -19,10 +19,16 @@ spec:
         endpoint: tempo-distributor.tracing.svc.cluster.local:4317
         tls:
           insecure: true
+      prometheus:                                                                                                                                                          │
+        endpoint: 0.0.0.0:9091
     service:
       pipelines:
         traces:
           receivers: [otlp]
           processors: []
           exporters: [logging, otlp]
+        metrics:
+          receivers: [otlp]
+          processors: []
+          exporters: [logging, prometheus]
 {{- end }}

--- a/charts/netigate-helm-template-acre/templates/service.yaml
+++ b/charts/netigate-helm-template-acre/templates/service.yaml
@@ -19,6 +19,12 @@ spec:
       protocol: TCP
       name: http-metrics
     {{- end }}
+    {{- if .Values.otlp.enabled }}
+    - port: 9091
+      targetPort: 9091
+      protocol: TCP
+      name: http-otlp-metrics
+    {{- end }}
     {{- if or .Values.grpc.enabled .Values.grpcExt.enabled }}
     - port: 443
       targetPort: https

--- a/charts/netigate-helm-template-acre/templates/servicemonitor.yaml
+++ b/charts/netigate-helm-template-acre/templates/servicemonitor.yaml
@@ -15,6 +15,11 @@ spec:
   - port: http-metrics
     path: /metrics
     interval: 15s
+  {{- if .Values.otlp.enabled }}
+  - port: http-otlp-metrics
+    path: /metrics
+    interval: 15s
+  {{- end }}
   podTargetLabels:
   - team
 {{- end }}


### PR DESCRIPTION
Adding application support for opentelemetry metrics.
Using 'otlp' application option the metrics are going to be converted to prometheus format and exposed for scraping on pod's port 9091.
To let our prometheus collect the metrics application still needs to enable 'metrics' feature.