### PR TITLE
Feat/update helm chart

### DIFF
--- a/charts/netigate-helm-template-acre/Chart.yaml
+++ b/charts/netigate-helm-template-acre/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.0-daas
+version: 4.1.1-daas-beta.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/netigate-helm-template-acre/Chart.yaml
+++ b/charts/netigate-helm-template-acre/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 4.1.1-daas-beta.1
+version: 4.1.1-daas
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/charts/netigate-helm-template-acre/templates/deployment.yaml
+++ b/charts/netigate-helm-template-acre/templates/deployment.yaml
@@ -44,6 +44,9 @@ spec:
 {{ toYaml .Values.initContainers | indent 10 }}
       {{- end}}
       containers:
+        {{- with .Values.sidecars }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
         - name: {{ .Values.name }}
           image: "{{ .Values.image }}:{{ .Values.tag }}"
           imagePullPolicy: IfNotPresent

--- a/charts/netigate-helm-template-acre/templates/deployment.yaml
+++ b/charts/netigate-helm-template-acre/templates/deployment.yaml
@@ -39,28 +39,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.initContainers }}
       initContainers:
-        {{- range .Values.initContainers }}
-        - name: {{ .name }}
-          image: {{ .image }}
-          imagePullPolicy: IfNotPresent
-          command:
-          {{- range $c := .commands }}
-            - {{ $c }}
-          {{- end }}
-          env:
-          {{- range .env }}
-            - name: {{ .name }}
-            {{- if .data }}
-              value: {{ .data | quote }}
-            {{- else }}
-              valueFrom:
-                {{ .valueFrom }}:
-                  name: {{ .refName }}
-                  key: {{ .name | quote }}
-            {{- end }}
-          {{- end }}
-        {{- end }}
+{{ toYaml .Values.initContainers | indent 10 }}
+      {{- end}}
       containers:
         - name: {{ .Values.name }}
           image: "{{ .Values.image }}:{{ .Values.tag }}"
@@ -181,6 +163,9 @@ spec:
             {{- end }}
           {{- end }}
           volumeMounts:
+          {{- range .Values.volumeMounts }}
+          - {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- if or .Values.grpc.enabled .Values.grpcExt.enabled }}
           - name: grpc
             mountPath: /netigate/cert/
@@ -257,6 +242,10 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       volumes:
+      {{- range .Values.volumes }}
+      - {{- toYaml . | nindent 12 }}
+      {{- end }}
+
       {{- if or .Values.grpc.enabled .Values.grpcExt.enabled }}
       - secret:
           secretName: wildcard.{{.Values.environmentFQDN}}

--- a/charts/netigate-helm-template-acre/templates/deployment.yaml
+++ b/charts/netigate-helm-template-acre/templates/deployment.yaml
@@ -257,6 +257,10 @@ spec:
           {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
+          {{- if .Values.commands }}
+          command:
+            {{- toYaml .Values.commands | nindent 12 }}
+          {{- end }}
       volumes:
       {{- range .Values.volumes }}
       - {{- toYaml . | nindent 12 }}

--- a/charts/netigate-helm-template-acre/templates/deployment.yaml
+++ b/charts/netigate-helm-template-acre/templates/deployment.yaml
@@ -197,7 +197,7 @@ spec:
             readOnly: true
           {{- end }}
           envFrom:
-            {{- if .Values.envVars}}
+            {{- if .Values.envVars }}
             - configMapRef:
                 name: {{ .Values.name }}-configmap
             {{- end }}
@@ -221,9 +221,17 @@ spec:
             {{- end }}
           {{- if .Values.livenessProbe.enabled }}
           livenessProbe:
+            {{- if .Values.livenessProbe.exec }}
+            exec:
+              command: 
+                {{- range .Values.livenessProbe.exec.command }}
+                - {{ . | quote }}
+                {{- end }}
+            {{- else }}
             httpGet:
               path: {{ .Values.livenessProbe.path | default "/health" }}
-              port: http
+              port: {{ .Values.livenessProbe.port | default "http" }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds | default 10 }}
             timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds | default 1 }}
             periodSeconds: {{ .Values.livenessProbe.periodSeconds | default 10 }}
@@ -231,9 +239,17 @@ spec:
           {{- end }}
           {{- if .Values.readinessProbe.enabled }}
           readinessProbe:
+            {{- if .Values.readinessProbe.exec }}
+            exec:
+              command: 
+                {{- range .Values.readinessProbe.exec.command }}
+                - {{ . | quote }}
+                {{- end }}
+            {{- else }}
             httpGet:
               path: {{ .Values.readinessProbe.path | default "/health" }}
               port: http
+            {{- end }}
             initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds | default 10 }}
             timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds | default 1 }}
             periodSeconds: {{ .Values.readinessProbe.periodSeconds | default 10 }}

--- a/charts/netigate-helm-template-acre/values.yaml
+++ b/charts/netigate-helm-template-acre/values.yaml
@@ -104,3 +104,11 @@ fieldRefs:
 
 otlp:
   enabled: false
+
+sidecars:
+
+initContainers:
+
+volumeMounts:
+
+volumes:


### PR DESCRIPTION
Update helm chart to support more use-cases, especially Kafka connect use cases, although nothing here is tied to Kafka connect, everything is generic helm..

- Added support for specifying sidecar containers
- Added support for executing commands in liveness/readiness probes (although it defaults to using httpGet if not explicitly specified)
- Add support for being able to add custom volumes & volume mounts
- Extend init containers support with volume mounts

Example values.yaml file with these changes
```yaml
livenessProbe:
  enabled: true
  exec:
    command:
    - bash
    - -c
    - |-
      health="$(curl -s http://localhost:8083/connectors/filter_data-connector-01/status | sed s/.*'tasks":\[{"id":.,"state":'/''/ | sed s@',.*'@''@)";
      if [ $health = '"RUNNING"' ]; then exit 0; else exit 2; fi;
      
commands:
- /bin/bash
- -c
- |
  echo "Creating aliases..."

volumeMounts:
- name: truststore
  mountPath: /etc/ssl/certs/java/cacerts

- name: truststore
  emptyDir: {}

sidecars:
- name: prometheus-jmx-exporter
  image: solsson/kafka-prometheus-jmx-exporter@sha256:6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
  imagePullPolicy: IfNotPresent
  command:
  - java
  - ...
```