### PR TITLE
feat(otel): resource request for otel sidecar

### DIFF
--- a/charts/namespace-v2/Chart.yaml
+++ b/charts/namespace-v2/Chart.yaml
@@ -6,4 +6,4 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8

--- a/charts/namespace-v2/templates/OpenTelemetryCollector.yaml
+++ b/charts/namespace-v2/templates/OpenTelemetryCollector.yaml
@@ -33,4 +33,7 @@ spec:
           receivers: [otlp]
           processors: []
           exporters: [logging, prometheus]
+  resources:
+    requests:
+      cpu: "25m" # 0.05 CPU
 {{- end }}


### PR DESCRIPTION
OTEL sidecar now has resource claims because HPA doesnt correctly work when it cannot fetch the CPU requests from the sidecar.

"_horizontal-pod-autoscaler  failed to get cpu utilization: missing request for cpu in container otc-container of Pod answer-analytics-service-57974b95c9-px2xc_"

