### PR TITLE
feat(netigate-helm-template-acre): support appending suffix to postgr…

### DIFF
--- a/charts/netigate-helm-template-acre/Chart.yaml
+++ b/charts/netigate-helm-template-acre/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v2
 name: netigate-template-acre
 description: A Helm chart template for netigate
 type: application
-version: 4.1.20
+version: 4.1.21

--- a/charts/netigate-helm-template-acre/templates/deployment.yaml
+++ b/charts/netigate-helm-template-acre/templates/deployment.yaml
@@ -98,6 +98,43 @@ spec:
               value: https://+:443
             {{- end }}
             {{- if .Values.postgres.enabled }}
+            {{- if .Values.postgres.connectionStringSuffix }}
+            - name: _PSQL_CS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}-postgres
+                  key: psql-connections-string
+            - name: ConnectionStrings__PostgresContext
+              value: "$(_PSQL_CS){{ .Values.postgres.connectionStringSuffix }}"
+            - name: _PSQL_CS_GENERIC
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}-postgres
+                  key: generic-psql-connections-string
+            - name: ConnectionStrings__PostgresContextGeneric
+              value: "$(_PSQL_CS_GENERIC){{ .Values.postgres.connectionStringSuffix }}"
+            - name: _PSQL_CS_GENERIC2
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}-postgres
+                  key: generic-psql-connections-string
+            - name: psql-connections-string
+              value: "$(_PSQL_CS_GENERIC2){{ .Values.postgres.connectionStringSuffix }}"
+            - name: _PSQL_CS_DIRECT
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}-postgres
+                  key: direct-psql-connections-string
+            - name: direct-psql-connections-string
+              value: "$(_PSQL_CS_DIRECT){{ .Values.postgres.connectionStringSuffix }}"
+            - name: _PSQL_CS_DIRECT_GENERIC
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Values.name }}-postgres
+                  key: direct-generic-psql-connections-string
+            - name: direct-generic-psql-connections-string
+              value: "$(_PSQL_CS_DIRECT_GENERIC){{ .Values.postgres.connectionStringSuffix }}"
+            {{- else }}
             - name: ConnectionStrings__PostgresContext
               valueFrom:
                 secretKeyRef:
@@ -123,6 +160,7 @@ spec:
                 secretKeyRef:
                   name: {{ .Values.name }}-postgres
                   key: direct-generic-psql-connections-string
+            {{- end }}
             {{- end }}
             {{- if .Values.kafka.enabled }}
             - name: EventBus__BootStrapServers

--- a/charts/netigate-helm-template-acre/templates/deployment.yaml
+++ b/charts/netigate-helm-template-acre/templates/deployment.yaml
@@ -113,13 +113,8 @@ spec:
                   key: generic-psql-connections-string
             - name: ConnectionStrings__PostgresContextGeneric
               value: "$(_PSQL_CS_GENERIC){{ .Values.postgres.connectionStringSuffix }}"
-            - name: _PSQL_CS_GENERIC2
-              valueFrom:
-                secretKeyRef:
-                  name: {{ .Values.name }}-postgres
-                  key: generic-psql-connections-string
             - name: psql-connections-string
-              value: "$(_PSQL_CS_GENERIC2){{ .Values.postgres.connectionStringSuffix }}"
+              value: "$(_PSQL_CS_GENERIC){{ .Values.postgres.connectionStringSuffix }}"
             - name: _PSQL_CS_DIRECT
               valueFrom:
                 secretKeyRef:

--- a/charts/netigate-helm-template-acre/values.yaml
+++ b/charts/netigate-helm-template-acre/values.yaml
@@ -162,6 +162,7 @@ postgres:
   enabled: false
   databaseServer:
   databaseName:
+  connectionStringSuffix:
 
 ## Set to true if you intend to use secrets from vault in your app.
 ## Only works when nodeSelector is set to linux


### PR DESCRIPTION
…es connection strings

Adds postgres.connectionStringSuffix to allow services to append parameters (e.g. ;GssEncryptionMode=Disable) to Vault-sourced connection strings via Kubernetes env var interpolation.